### PR TITLE
refactor async operation

### DIFF
--- a/api/async.rb
+++ b/api/async.rb
@@ -37,6 +37,7 @@ module Api
       attr_reader :base_url
       attr_reader :wait_ms
       attr_reader :timeouts
+      attr_reader :service_type
 
       def validate
         super
@@ -48,6 +49,7 @@ module Api
         check_property :base_url, String
         check_property :wait_ms, Integer
         check_property :timeouts, Timeouts
+	check_optional_property :service_type, String
       end
 
       # Provides timeout information for the different operation types
@@ -79,10 +81,11 @@ module Api
     # Represents the results of an Operation request
     class Result < Api::Object
       attr_reader :path
-
+      attr_reader :base_url
       def validate
         super
         check_property :path, String
+	check_property :base_url, String
       end
     end
 

--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -2,27 +2,27 @@
 <%
   stat_path = path2navigate(object.async.status.path)
   res_path = path2navigate(object.async.result.path)
+  op_path = path2navigate(object.async.operation.path)
+  async_url = async_operation_url(object, object.async.operation.base_url)
+  res_url = async_operation_url(object, object.async.result.base_url)
 -%>
+def resource_get_url(module, wait_done):
+    op_id = navigate_hash(wait_done, <%= res_path -%>)
+    endpoint = get_service_endpoint(module, <%=quote_string(object.service_type)%>)
+    url = <%=quote_string(res_url)%>.format({'op_id': op_id})
+    return endpoint + url
+
+
 <%=
-  lines(emit_link('async_op_url', async_operation_url(object), object, true), 2)
+  lines(emit_link('async_op_url', async_url, object, true, object.async.operation.service_type || object.service_type), 2)
 -%>
-def wait_for_operation(module, response):
-<% if object.kind? -%>
-<%   op_kind = object.async.operation.kind -%>
-    op_result = return_if_object(module, response, '<%= op_kind -%>')
-<% else # object.kind? -%>
-    op_result = return_if_object(module, response)
-<% end # object.kind? -%>
-    if op_result is None:
-        return None
-    status = navigate_hash(op_result, <%= stat_path -%>)
+def wait_for_operation(module, op_type, op_result):
+    op_id = navigate_hash(op_result, <%= op_path -%>)
+    url = async_op_url(module, {'op_id': op_id})
+    timeout = module.params['timeouts'][op_type]
+
 <% if object.self_link_query.nil? -%>
-    wait_done = wait_for_completion(status, op_result, module)
-<%   if object.kind? -%>
-    return fetch_resource(module, navigate_hash(wait_done, <%= res_path -%>), <%= quote_string(object.kind) -%>)
-<%   else # object.kind? -%>
-    return fetch_resource(module, navigate_hash(wait_done, <%= res_path -%>))
-<%   end # object.kind? -%>
+    return wait_for_completion(url, timeout, module)
 <% else # object.self_link_query.nil? -%>
     wait_for_completion(status, op_result, resource)
 <%=
@@ -55,31 +55,46 @@ def wait_for_operation(module, response):
 <% end # object.self_link_query.nil? -%>
 
 
-def wait_for_completion(status, op_result, module):
+def wait_for_completion(op_uri, timeout, module):
 <%
-  op_path = path2navigate(object.async.operation.path)
   err_path = path2navigate(object.async.error.path)
-  err_msg = object.async.error.message
+  # err_msg = object.async.error.message
   allowed_states = object.async.status.allowed.map { |x| quote_string(x) }
 -%>
-    op_id = navigate_hash(op_result, <%= op_path -%>)
-    op_uri = async_op_url(module, {'op_id': op_id})
-    while status != '<%= object.async.status.complete -%>':
-        raise_if_errors(op_result, <%= err_path -%>, '<%= err_msg -%>')
-        time.sleep(<%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>)
+    start = time.time()
+    time_passed = 0
+    while time_passed <= timeout:
+        try:
+<% if object.kind? -%>
+            op_result = fetch_resource(module, op_uri, '<%= op_kind -%>')
+<% else # object.kind? -%>
+            op_result = fetch_resource(module, op_uri)
+<% end # object.kind? -%>
+        except Exception:
+            time.sleep(<%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>)
+            time_passed = time.time() - start
+            continue
+
+        raise_if_errors(op_result, module)
+
+        status = navigate_hash(op_result, <%= stat_path -%>)
         if status not in [<%= allowed_states.join(', ') -%>]:
             module.fail_json(msg="Invalid result %s" % status)
-<% if object.kind? -%>
-        op_result = fetch_resource(module, op_uri, '<%= op_kind -%>')
-<% else # object.kind? -%>
-        op_result = fetch_resource(module, op_uri)
-<% end # object.kind? -%>
-        status = navigate_hash(op_result, <%= stat_path -%>)
-    return op_result
+        if status == '<%= object.async.status.complete -%>': 
+            return op_result
+
+        time.sleep(<%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>)
+        time_passed = time.time() - start
+
+    module.fail_json("Timeout to wait completion")
 
 
-def raise_if_errors(response, err_path, module):
-    errors = navigate_hash(response, err_path)
-    if errors is not None:
-        module.fail_json(msg=errors)
+def raise_if_errors(response, module):
+<%
+  err_path = path2navigate(object.async.error.path)
+  err_msg = path2navigate(object.async.error.message)
+-%>
+    errors = navigate_hash(response, <%= err_path -%>)
+    if errors:
+        module.fail_json(msg=navigate_hash(response, <%= err_msg -%>))
 <% end #if object.async -%>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -48,7 +48,7 @@ extends_documentation_fragment: gcp
 
 <% if example -%>
 EXAMPLES = '''
-<% res_readable_name = Google::StringUtils.uncombine(object.name) -%>
+<%#<% res_readable_name = Google::StringUtils.uncombine(object.name) -%>
 <% if example.dependencies -%>
 <%   example.dependencies.each do |depend| -%>
 <%= lines(depend.build_test('present', object, false)) -%>
@@ -109,11 +109,10 @@ def main():
 <% if object.msg_prefix -%>
     msg_prefix = <%= quote_string(object.msg_prefix) %>
 <% end  # object.msg_prefix -%>
-    endpoint = get_service_endpoint(module, <%= quote_string(object.service_type) -%>)
 
 <% if object.self_link_query.nil? -%>
 <%
-  method = method_call('fetch_resource', ['module', 'endpoint + self_link(module)',
+  method = method_call('fetch_resource', ['module', 'self_link(module)',
                                           ('kind' if object.kind?),
 					  ('[' + object.get_codes.join(', ') + ']' if object.get_codes)
                                          ])
@@ -139,7 +138,7 @@ def main():
             if is_different(module, fetch):
 <%
   method = method_call('update', [
-                                   'module', 'endpoint + self_link(module)',
+                                   'module', 'self_link(module)',
                                    ('kind' if object.kind?),
                                    ('fetch' if object.save_api_results?),
                                    ('[' + object.update_codes.join(', ') + ']' if object.update_codes)
@@ -154,7 +153,7 @@ def main():
         else:
 <%
   method = method_call('delete', [
-                                   'module', 'endpoint + self_link(module)',
+                                   'module', 'self_link(module)',
                                    ('kind' if object.kind?),
 				   ('fetch' if object.save_api_results?),
 				   ('[' + object.delete_codes.join(', ') + ']' if object.delete_codes)
@@ -167,9 +166,9 @@ def main():
         if state == 'present':
 <%
   if object.create_verb.nil? || object.create_verb == :POST
-    create_link = 'endpoint + collection(module)'
+    create_link = 'collection(module)'
   elsif object.create_verb == :PUT
-    create_link = 'endpoint + self_link(module)'
+    create_link = 'self_link(module)'
   else
     raise "Ansible does not support create_verb #{object.create_verb}"
   end
@@ -210,7 +209,7 @@ def main():
 -%>
 <%
   method = method_call(
-    object.async ? 'wait_for_operation' : 'return_if_object',
+    'return_if_object',
     ['module',
      method_call("auth#{create_verb}",
                  ['link', 'resource_to_request(module)']),
@@ -219,7 +218,22 @@ def main():
    ]
   )
 -%>
+<%   if not object.async -%>
     return <%= method %>
+<%   else -%>
+    r = <%= method %>
+
+    wait_done = wait_for_operation(module, 'create', r)
+
+    url = resource_get_url(module, wait_done)
+<%
+  method = method_call('fetch_resource', ['module', 'url',
+                                          ('kind' if object.kind?),
+					  ('[' + object.get_codes.join(', ') + ']' if object.get_codes)
+                                         ])
+-%>
+    return <%= method %>
+<%   end -%>
 <% else -%>
 <%= lines(indent(object.create, 4)) -%>
 <% end -%>
@@ -237,7 +251,7 @@ def main():
         success_codes = [201, 202]
 <%
   method = method_call(
-    object.async ? 'wait_for_operation' : 'return_if_object',
+    'return_if_object',
     [
      'module',
      method_call("auth.put", ['link', 'resource_to_request(module)']),
@@ -246,7 +260,22 @@ def main():
    ]
   )
 -%>
+<%   if not object.async -%>
     return <%= method %>
+<%   else -%>
+    r = <%= method %>
+
+    wait_done = wait_for_operation(module, 'update', r)
+
+    url = resource_get_url(module, wait_done)
+<%
+  method = method_call('fetch_resource', ['module', 'url',
+                                          ('kind' if object.kind?),
+					  ('[' + object.get_codes.join(', ') + ']' if object.get_codes)
+                                         ])
+-%>
+    return <%= method %>
+<%     end -%>
 <%   else # !false?(object.editable) -%>
     module.fail_json(msg="<%= object.name -%> cannot be edited")
 <%   end # !false?(object.editable) -%>
@@ -266,7 +295,7 @@ def main():
         success_codes = [202, 204]
 <%
   method = method_call(
-    object.async ? 'wait_for_operation' : 'return_if_object',
+    'return_if_object',
     ['module',
      method_call("auth.delete", ['link']),
      ('kind' if !object.async && object.kind?),
@@ -275,7 +304,13 @@ def main():
    ]
   )
 -%>
+<%   if not object.async -%>
     return <%= method %>
+<%   else -%>
+    r = <%= method %>
+
+    return wait_for_operation(module, 'delete', r)
+<%   end -%>
 <% else # if object.delete.nil? -%>
 <%= lines(indent(object.delete, 4)) -%>
 <% end # if object.delete.nil? -%>
@@ -283,10 +318,10 @@ def main():
 
 <% end # unless object.virtual -%>
 <%= lines(compile('templates/ansible/transport.erb'), 2) -%>
-<%= lines(emit_link('self_link', self_link_url(object), object)) -%>
+<%= lines(emit_link('self_link', self_link_url(object), object, false, object.service_type)) -%>
 
 
-<%= lines(emit_link('collection', collection_url(object), object)) -%>
+<%= lines(emit_link('collection', collection_url(object), object, false, object.service_type)) -%>
 
 
 def get_service_endpoint(module, service_type):
@@ -319,10 +354,11 @@ def get_service_endpoint(module, service_type):
     result = <%= object.transport.decoder -%>(result, module)
 
 <% end -%>
-    if navigate_hash(result, ['error', 'errors']):
-        module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
-    elif code not in success_codes:
-        module.fail_json(msg="operation failed, return code=%d" % code)
+    if code not in success_codes:
+        if navigate_hash(result, ['error', 'errors']):
+            module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
+        else:
+            module.fail_json(msg="operation failed, return code=%d" % code)
 <% if object.kind? -%>
     if result['kind'] != kind:
         module.fail_json(msg="Incorrect result: {kind}".format(**result))

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -272,39 +272,6 @@ def main():
 
 
 <% end # unless object.virtual -%>
-def _convert_input(module):
-<%
-  properties_in_request = [
-    object&.parameters&.select { |p| p.input },
-    object.properties.reject(&:output)
-  ].flatten.compact
--%>
-    request = {
-<% if object.kind? -%>
-        u'kind': <%= quote_string(object.kind) -%>,
-<% end # if object.kind? -%>
-<%= lines(indent(request_properties(properties_in_request), 4)) -%>
-    }
-<% if object.encoder? -%>
-    request = <%= object.transport.encoder -%>(request, module)
-<% end -%>
-    return_vals = {}
-    for k, v in request.items():
-        if v:
-            return_vals[k] = v
-
-    return return_vals
-
-
-def resource_to_request(module):
-    v = _convert_input(module)
-<% if object.msg_prefix -%>
-    return {'<%= object.msg_prefix %>': v}
-<% else -%>
-    return v
-<% end -%>
-
-
 <%= lines(compile('templates/ansible/transport.erb'), 2) -%>
 <%= lines(emit_link('self_link', self_link_url(object), object)) -%>
 
@@ -375,6 +342,39 @@ def is_different(module, response):
             request_vals[k] = v
 
     return DictComparison(request_vals) != DictComparison(response_vals)
+
+
+def _convert_input(module):
+<%
+  properties_in_request = [
+    object&.parameters&.select { |p| p.input },
+    object.properties.reject(&:output)
+  ].flatten.compact
+-%>
+    request = {
+<% if object.kind? -%>
+        u'kind': <%= quote_string(object.kind) -%>,
+<% end # if object.kind? -%>
+<%= lines(indent(request_properties(properties_in_request), 4)) -%>
+    }
+<% if object.encoder? -%>
+    request = <%= object.transport.encoder -%>(request, module)
+<% end -%>
+    return_vals = {}
+    for k, v in request.items():
+        if v:
+            return_vals[k] = v
+
+    return return_vals
+
+
+def resource_to_request(module):
+    v = _convert_input(module)
+<% if object.msg_prefix -%>
+    return {'<%= object.msg_prefix %>': v}
+<% else -%>
+    return v
+<% end -%>
 
 
 # Remove unnecessary properties from the response.

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -106,6 +106,9 @@ def main():
 <% if object.kind? -%>
     kind = <%= lines(quote_string(object.kind)) -%>
 <% end -%>
+<% if object.msg_prefix -%>
+    msg_prefix = <%= quote_string(object.msg_prefix) %>
+<% end  # object.msg_prefix -%>
     endpoint = get_service_endpoint(module, <%= quote_string(object.service_type) -%>)
 
 <% if object.self_link_query.nil? -%>
@@ -128,6 +131,10 @@ def main():
 <% else # object.virtual -%>
 
     if fetch:
+<% if object.msg_prefix -%>
+        fetch = fetch.get(msg_prefix)
+<% end  # object.msg_prefix -%>
+
         if state == 'present':
             if is_different(module, fetch):
 <%
@@ -139,6 +146,9 @@ def main():
                                  ])
 -%>
 <%= lines(indent("fetch = #{method}", 16)) -%>
+<% if object.msg_prefix -%>
+                fetch = fetch.get(msg_prefix)
+<% end  # object.msg_prefix -%>
                 changed = True
             fetch = response_to_hash(module, fetch)
         else:
@@ -168,8 +178,8 @@ def main():
 				  ('[' + object.create_codes.join(', ') + ']' if object.create_codes)])
 -%>
             fetch = <%= method %>
+            fetch = response_to_hash(module, <%= object.msg_prefix ? 'fetch.get(msg_prefix)' : 'fetch'%>)
             changed = True
-            fetch = response_to_hash(module, fetch)
         else:
             fetch = {}
 
@@ -299,6 +309,7 @@ def get_service_endpoint(module, service_type):
     if code in success_codes and not has_content:
         return None
 
+    result = None
     try:
         result = response.json()
     except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
@@ -317,11 +328,7 @@ def get_service_endpoint(module, service_type):
         module.fail_json(msg="Incorrect result: {kind}".format(**result))
 <% end # object.kind? -%>
 
-<% if object.msg_prefix -%>
-    return result.get("<%= object.msg_prefix %>")
-<% else # object.msg_prefix -%>
     return result
-<% end  # object.msg_prefix -%>
 
 
 def is_different(module, response):


### PR DESCRIPTION
this pr includes several modifications:

1. If the message body includes a prefix, then strip it where parses message.

2. add a attribute of 'service_type' for async.opertion, which will be used to get the endpoint of async operation. If it is not set in the async.yaml, then use resource.service_type instead. Please note: the format of async.operation.base_url is: **/**/{{op_id}}. for example, for compute instance service, the url is 'servers/{{op_id}}'

3. add a attribute of 'base_url' for async.result, which will be used to generate the Get url of original resource. And its format is like async.operation.base_url

4. It changes the way to generate the url for resource and async operation. The url composes of endpoint and 'base_url'. 'endpoint' is generated by querying IAM , and 'base_url' is set in api.yaml or async.yaml.

5. It modify the method of 'wait_for_completion' to support timeouts

6. It changes the methods of 'create',  'update' etc and 'wait_for_operation' to make async operation more reasonable.