### PR TITLE
support custom methods for building req/resp parameters

### DIFF
--- a/provider/ansible/property_override.rb
+++ b/provider/ansible/property_override.rb
@@ -21,6 +21,8 @@ module Provider
     # Ansible. All fields should be `attr_reader :<property>`
     module OverrideFields
       attr_reader :aliases
+      attr_reader :to_request
+      attr_reader :from_response
     end
 
     # Ansible-specific overrides to api.yaml.
@@ -30,6 +32,8 @@ module Provider
         super
 
         check_optional_property :aliases, ::Array
+        check_optional_property :to_request, ::String
+        check_optional_property :from_response, ::String
       end
 
       private

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -89,8 +89,11 @@ module Provider
       private
 
       def request_property(prop, hash_name, module_name)
+        fn = prop.field_name
+        fn = fn.include?("/") ? fn[0, fn.index("/")] : fn
+
         [
-          "#{unicode_string(prop.field_name)}:",
+          "#{unicode_string(fn)}:",
           request_output(prop, hash_name, module_name).to_s
         ].join(' ')
       end
@@ -107,26 +110,28 @@ module Provider
         # If input true, treat like request, but use module names.
         return request_output(prop, "#{module_name}.params", module_name) \
           if prop.input
+        fn = prop.field_name
+        fn = fn.include?("/") ? fn[fn.index("/") + 1..-1] : fn
         if prop.is_a? Api::Type::NestedObject
           [
             "#{prop.property_class[-1]}(",
-            "#{hash_name}.get(#{unicode_string(prop.field_name)}, {})",
+            "#{hash_name}.get(#{unicode_string(fn)}, {})",
             ", #{module_name}).from_response()"
           ].join
         elsif prop.is_a?(Api::Type::Array) && \
               prop.item_type.is_a?(Api::Type::NestedObject)
           [
             "#{prop.property_class[-1]}(",
-            "#{hash_name}.get(#{unicode_string(prop.field_name)}, [])",
+            "#{hash_name}.get(#{unicode_string(fn)}, [])",
             ", #{module_name}).from_response()"
           ].join
         elsif prop.from_response
           [
             "_#{prop.out_name}_convert_from_response(",
-            "#{hash_name}.get(#{quote_string(prop.field_name)}))",
+            "#{hash_name}.get(#{quote_string(fn)}))",
           ].join
         else
-          "#{hash_name}.get(#{unicode_string(prop.field_name)})"
+          "#{hash_name}.get(#{unicode_string(fn)})"
         end
       end
       # rubocop:enable Metrics/MethodLength

--- a/templates/ansible/properties.erb
+++ b/templates/ansible/properties.erb
@@ -9,14 +9,22 @@ class <%= prop.property_class[-1] -%>(object):
             self.request = {}
 
     def to_request(self):
+<%   if prop.to_request -%>
+<%= lines(indent(prop.to_request, 8)) -%>
+<%   else -%>
         return remove_nones_from_dict({
 <%= lines(request_properties_in_classes(prop.properties, 12)) -%>
         })
+<%   end -%>
 
     def from_response(self):
+<%   if prop.from_response -%>
+<%= lines(indent(prop.from_response, 8)) -%>
+<%   else -%>
         return remove_nones_from_dict({
 <%= lines(response_properties_in_classes(prop.properties, 12)) -%>
         })
+<%   end -%>
 <% elsif prop.is_a?(Api::Type::Array) && prop.item_type.is_a?(Api::Type::NestedObject) -%>
     def __init__(self, request, module):
         self.module = module
@@ -26,16 +34,25 @@ class <%= prop.property_class[-1] -%>(object):
             self.request = []
 
     def to_request(self):
+<%   if prop.to_request -%>
+<%= lines(indent(prop.to_request, 8)) -%>
+<%   else -%>
         items = []
         for item in self.request:
             items.append(self._request_for_item(item))
         return items
+<%   end -%>
 
     def from_response(self):
+<%   if prop.from_response -%>
+<%= lines(indent(prop.from_response, 8)) -%>
+<%   else -%>
         items = []
         for item in self.request:
             items.append(self._response_from_item(item))
         return items
+<%   end -%>
+<%   if not prop.to_request -%>
 
     def _request_for_item(self, item):
         return remove_nones_from_dict({
@@ -43,6 +60,8 @@ class <%= prop.property_class[-1] -%>(object):
   lines(request_properties_in_classes(prop.item_type.properties, 12, 'item'))
 -%>
         })
+<%   end -%>
+<%   if not prop.from_response -%>
 
     def _response_from_item(self, item):
         return remove_nones_from_dict({
@@ -50,6 +69,7 @@ class <%= prop.property_class[-1] -%>(object):
   lines(response_properties_in_classes(prop.item_type.properties, 12, 'item'))
 -%>
         })
+<%   end -%>
 <% end # prop.is_a? NestedObject -%>
 <%=
   unless prop == properties_with_classes(object.all_user_properties).last

--- a/templates/ansible/properties.erb
+++ b/templates/ansible/properties.erb
@@ -57,3 +57,15 @@ class <%= prop.property_class[-1] -%>(object):
   end
 -%>
 <% end -%>
+<% properties_with_custom_method_for_param(object.all_user_properties).each do |prop| -%>
+<%   if prop.to_request -%>
+<%= "\n" * 2 -%>
+def _<%= prop.out_name -%>_convert_to_request(param):
+<%= lines(indent(prop.to_request, 4)) -%>
+<%   end -%>
+<%   if prop.from_response -%>
+<%= "\n" * 2 -%>
+def _<%= prop.out_name -%>_convert_from_response(param):
+<%= lines(indent(prop.from_response, 4)) -%>
+<%   end -%>
+<% end -%>

--- a/templates/ansible/properties.erb
+++ b/templates/ansible/properties.erb
@@ -25,6 +25,20 @@ class <%= prop.property_class[-1] -%>(object):
 <%= lines(response_properties_in_classes(prop.properties, 12)) -%>
         })
 <%   end -%>
+<%   properties_with_custom_method_for_param(prop.properties).each do |p| -%>
+<%     if p.to_request -%>
+
+    @staticmethod
+    def _<%= p.out_name -%>_convert_to_request(value):
+<%= lines(indent(p.to_request, 8)) -%>
+<%     end -%>
+<%     if p.from_response -%>
+
+    @staticmethod
+    def _<%= p.out_name -%>_convert_from_response(value):
+<%= lines(indent(p.from_response, 8)) -%>
+<%     end -%>
+<%   end -%>
 <% elsif prop.is_a?(Api::Type::Array) && prop.item_type.is_a?(Api::Type::NestedObject) -%>
     def __init__(self, request, module):
         self.module = module
@@ -70,6 +84,20 @@ class <%= prop.property_class[-1] -%>(object):
 -%>
         })
 <%   end -%>
+<%   properties_with_custom_method_for_param(prop.item_type.properties).each do |p| -%>
+<%     if p.to_request -%>
+
+    @staticmethod
+    def _<%= p.out_name -%>_convert_to_request(value):
+<%= lines(indent(p.to_request, 8)) -%>
+<%     end -%>
+<%     if p.from_response -%>
+
+    @staticmethod
+    def _<%= p.out_name -%>_convert_from_response(value):
+<%= lines(indent(p.from_response, 8)) -%>
+<%     end -%>
+<%   end -%>
 <% end # prop.is_a? NestedObject -%>
 <%=
   unless prop == properties_with_classes(object.all_user_properties).last
@@ -80,12 +108,12 @@ class <%= prop.property_class[-1] -%>(object):
 <% properties_with_custom_method_for_param(object.all_user_properties).each do |prop| -%>
 <%   if prop.to_request -%>
 <%= "\n" * 2 -%>
-def _<%= prop.out_name -%>_convert_to_request(param):
+def _<%= prop.out_name -%>_convert_to_request(value):
 <%= lines(indent(prop.to_request, 4)) -%>
 <%   end -%>
 <%   if prop.from_response -%>
 <%= "\n" * 2 -%>
-def _<%= prop.out_name -%>_convert_from_response(param):
+def _<%= prop.out_name -%>_convert_from_response(value):
 <%= lines(indent(prop.from_response, 4)) -%>
 <%   end -%>
 <% end -%>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -431,5 +431,6 @@ def response_to_hash(module, response):
 <%= lines_before(compile('templates/ansible/provider_helpers.erb'), 1) -%>
 <%= lines_before(compile('templates/ansible/properties.erb'), 1) -%>
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
commit 1:  import two attribute for property overrides, which will be used to define custom method for building req/resp parameter.  support custom method for properties on the top level.

commit 2:  support a parameter with different names on Create and Get operation respectively. The example is the parameter of 'availability_zone' for Nova.servers

commit 3:  support custom methods for complex parameters, like map, array.

commit 4:  support custom methods for any child parameter of complex one.  for example
  p1: {
    p2: {
      name: str
      value: str
    }
    p3: str
  }

  commit 4 can support custom method for p1.p2.name

note: the original codes of [property_overrides.rb](https://github.com/huaweicloud/magic-modules/blob/master/provider/resource_overrides.rb#L109-L147) supports override for any child property. it is so much beautiful!