### PR TITLE
build parameters for create/update

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -31,6 +31,11 @@ module Api
       attr_reader :required
       attr_reader :update_verb
       attr_reader :update_url
+      # Specify which API this filed belongs to, create or update or both.
+      # c:  this field is only the parameter of create
+      # u:  this field is only the parameter of update
+      # cu: both
+      attr_reader :create_update
     end
 
     include Fields
@@ -57,6 +62,9 @@ module Api
       check_optional_property_oneof_default \
         :update_verb, %i[POST PUT PATCH NONE], @__resource&.update_verb, Symbol
       check_optional_property :update_url, ::String
+      check_optional_property :create_update, ::String
+      check_optional_property_oneof_default \
+        :create_update, %w(c u cu), nil, ::String
     end
 
     def type

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -212,7 +212,7 @@ def main():
     'return_if_object',
     ['module',
      method_call("auth#{create_verb}",
-                 ['link', 'resource_to_request(module)']),
+                 ['link', 'resource_to_create(module)']),
      ('kind' if !object.async && object.kind?),
      'success_codes'
    ]
@@ -254,7 +254,7 @@ def main():
     'return_if_object',
     [
      'module',
-     method_call("auth.put", ['link', 'resource_to_request(module)']),
+     method_call("auth.put", ['link', 'resource_to_update(module)']),
      ('kind' if !object.async && object.kind?),
      'success_codes'
    ]
@@ -387,6 +387,82 @@ def is_different(module, response):
     return DictComparison(request_vals) != DictComparison(response_vals)
 
 
+def resource_to_create(module):
+<%
+  properties_in_request = [
+    object&.parameters&.reject(&:alone_parameter)&.select { |p| p.input || p.create_update == 'c' || p.create_update == 'cu' },
+    object.properties.reject(&:output).select { |p| p.create_update == 'c' || p.create_update == 'cu' },
+  ].flatten.compact
+-%>
+    request = remove_nones_from_dict({
+<% if object.kind? -%>
+        u'kind': <%= quote_string(object.kind) -%>,
+<% end # if object.kind? -%>
+<%= lines(indent(request_properties(properties_in_request), 4)) -%>
+    })
+<%
+  alone = object.alone_parameters.select { |p| p.input || p.create_update == 'c' || p.create_update == 'cu' }
+-%>
+<% if not alone.empty? -%>
+    alone_param = remove_nones_from_dict({
+ <%= lines(indent(request_properties(alone), 4)) -%>
+    })
+<% end -%>
+<% if object.msg_prefix -%>
+<%   if alone.empty? -%>
+    return {'<%= object.msg_prefix %>': request}
+<%   else -%>
+    v = {'<%= object.msg_prefix %>': request}
+    v.update(alone_param)
+    return v
+<%   end -%>
+<% else -%>
+<%   if alone.empty? -%>
+    return request
+<%   else -%>
+    return request.update(alone_param)
+<%   end -%>
+<% end -%>
+
+
+def resource_to_update(module):
+<%
+  properties_in_request = [
+    object&.parameters&.reject(&:alone_parameter)&.select { |p| p.create_update == 'u' || p.create_update == 'cu' },
+    object.properties.reject(&:output).select { |p| p.create_update == 'u' || p.create_update == 'cu' },
+  ].flatten.compact
+-%>
+    request = remove_nones_from_dict({
+<% if object.kind? -%>
+        u'kind': <%= quote_string(object.kind) -%>,
+<% end # if object.kind? -%>
+<%= lines(indent(request_properties(properties_in_request), 4)) -%>
+    })
+<%
+  alone = object.alone_parameters.select { |p| p.create_update == 'u' || p.create_update == 'cu' }
+-%>
+<% if not alone.empty? -%>
+    alone_param = remove_nones_from_dict({
+ <%= lines(indent(request_properties(alone), 4)) -%>
+    })
+<% end -%>
+<% if object.msg_prefix -%>
+<%   if alone.empty? -%>
+    return {'<%= object.msg_prefix %>': request}
+<%   else -%>
+    v = {'<%= object.msg_prefix %>': request}
+    v.update(alone_param)
+    return v
+<%   end -%>
+<% else -%>
+<%   if alone.empty? -%>
+    return request
+<%   else -%>
+    return request.update(alone_param)
+<%   end -%>
+<% end -%>
+
+
 def _convert_input(module):
 <%
   properties_in_request = [
@@ -409,49 +485,6 @@ def _convert_input(module):
             return_vals[k] = v
 
     return return_vals
-
-
-<% if not object.alone_parameters.select(&:input).empty? -%>
-def _convert_alone_input_param(module):
-<%
-  properties_in_request = object.alone_parameters.select(&:input)
--%>
-    request = {
-<% if object.kind? -%>
-        u'kind': <%= quote_string(object.kind) -%>,
-<% end # if object.kind? -%>
-<%= lines(indent(request_properties(properties_in_request), 4)) -%>
-    }
-<% if object.encoder? -%>
-    request = <%= object.transport.encoder -%>(request, module)
-<% end -%>
-    return_vals = {}
-    for k, v in request.items():
-        if v:
-            return_vals[k] = v
-
-    return return_vals
-<% end -%>
-
-def resource_to_request(module):
-<% has_alone_param = (not object.alone_parameters.select(&:input).empty?) -%>
-<% if object.msg_prefix -%>
-<%   if has_alone_param -%>
-    v = {'<%= object.msg_prefix %>': _convert_input(module)}
-    v.update(_convert_alone_input_param(module))
-    return v
-<%   else -%>
-    return {'<%= object.msg_prefix %>': _convert_input(module)}
-<%   end -%>
-<% else -%>
-<%   if has_alone_param -%>
-    v = _convert_input(module)
-    v.update(_convert_alone_input_param(module))
-    return v
-<%   else -%>
-    return _convert_input(module)
-<%   end -%>
-<% end -%>
 
 
 # Remove unnecessary properties from the response.


### PR DESCRIPTION
add an attribute 'create_update' to the fields of property, which is used to specify which api's parametes this property belongs to. It can use this attribute to build message body for create/update operation.