### PR TITLE
support index resource by name

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -50,6 +50,7 @@ module Api
       attr_reader :get_codes    # the successful codes of Get
       attr_reader :delete_codes # the successful codes of Delete
       attr_reader :service_type # the endpoint service type of this resource
+      attr_reader :list_url     # the list url of the resource
     end
 
     include Properties
@@ -246,6 +247,8 @@ module Api
       check_optional_property_list :delete_codes, Integer
       check_optional_property_list :get_codes, Integer
       check_property :service_type, String
+      check_property :list_url, String
+      check_optional_property :list_msg_prefix, String
 
       check_property :properties, Array unless @exclude
 
@@ -291,6 +294,10 @@ module Api
 
     def required_properties
       all_user_properties.select(&:required)
+    end
+
+    def list_msg_prefix
+      @list_msg_prefix || @msg_prefix + 's'
     end
 
     def exported_properties

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -107,6 +107,15 @@ module Provider
         "#{full_url.gsub('{{', '{').gsub('}}', '}')}"
       end
 
+      def list_url(resource)
+        base_url = resource.list_url.split("\n").map(&:strip).compact
+        full_url = [resource.__product.default_version.base_url,
+                    base_url].flatten.join
+        # Double {} replaced with single {} to support Python string
+        # interpolation
+        "#{full_url.gsub('{{', '{').gsub('}}', '}')}"
+      end
+
       def async_operation_url(resource, url)
         base_url = resource.__product.default_version.base_url
         url = [base_url, url].join

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -131,7 +131,7 @@ module Provider
 
       def validate
         raise 'Region must be slash delineated (e.g. regions/us-west1)' \
-          unless @region == 'global' || @region.match?(%r{.*\/.*})
+          unless @region == 'global' || @region.match(%r{.*\/.*})
 
         check_optional_property :type, ::String
 
@@ -192,8 +192,8 @@ module Provider
             "#{@name}:",
             indent([
                      compile_string(hash, @code),
-                     'scopes:',
-                     indent(lines(scopes), 2),
+                     # 'scopes:',
+                     # indent(lines(scopes), 2),
                      "state: #{state}"
                    ], 4),
             ("register: #{@register}" unless @register.nil?)
@@ -204,7 +204,7 @@ module Provider
       # rubocop:enable Metrics/CyclomaticComplexity
 
       def object_name_from_module_name(mod_name)
-        product_name = mod_name.match(/gcp_[a-z]*_(.*)/).captures[0]
+        product_name = mod_name.match(/hw_[a-z]*_(.*)/).captures[0]
         product_name.tr('_', ' ')
       end
 

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -129,6 +129,11 @@ def main():
 					  ('[' + object.get_codes.join(', ') + ']' if object.get_codes)
                                          ])
 -%>
+<% if self_link_url(object).match('/{id}') -%>
+    if (not module.params.get("id")) and module.params.get("name"):
+        module.params['id'] = get_id_by_name(module)
+
+<% end -%>
     fetch = None
     link = self_link(module)
     # the link will include Nones if required format parameters are missed
@@ -354,6 +359,58 @@ def main():
 
 <% end # unless object.virtual -%>
 <%= lines(compile('templates/ansible/transport.erb'), 2) -%>
+<% unless object.virtual || self_link_url(object).match('/{id}').nil? -%>
+def get_id_by_name(module):
+    name = module.params.get("name")
+    link = list_link(module, {'limit': 10, 'marker': '{marker}'})
+    not_format_keys = re.findall("={marker}", link)
+    none_values = re.findall("=None", link)
+
+    if not (not_format_keys or none_values):
+        r = fetch_resource(module, link)
+        if r is None:
+            return ""
+<%   if object.list_msg_prefix -%>
+        r = r.get(<%= quote_string(object.list_msg_prefix) %>, [])
+<%   end  # object.msg_prefix -%>
+        ids = [
+            i.get('id') for i in r if i.get('name', '') == name
+        ]
+        if not ids:
+            return ""
+        elif len(ids) == 1:
+            return ids[0]
+        else:
+            module.fail_json(msg="Multiple resources with same name are found")
+    elif none_values:
+        module.fail_json(msg="Can not find id by name because url includes None")
+    else:
+        p = {'marker': ''}
+        ids = set()
+        while True:
+            r = fetch_resource(module, link.format(**p))
+            if r is None:
+                break
+<%   if object.list_msg_prefix -%>
+            r = r.get(<%= quote_string(object.list_msg_prefix) %>, [])
+<%   end  # object.msg_prefix -%>
+            if r == []:
+                break
+            for i in r:
+                if i.get('name') == name:
+                    ids.add(i.get('id'))
+            if len(ids) >= 2:
+                module.fail_json(msg="Multiple resources with same name are found")
+
+            p['marker'] = r[-1].get('id')
+
+        return ids.pop() if ids else ""
+
+
+<%= lines(emit_link('list_link', list_url(object), object, true, object.service_type)) -%>
+
+
+<% end -%>
 <%= lines(emit_link('self_link', self_link_url(object), object, false, object.service_type)) -%>
 
 

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -45,8 +45,7 @@ options:
 <% end -%>
 '''
 
-<%#if example -%>
-<% if false -%>
+<%if example -%>
 EXAMPLES = '''
 <%#<% res_readable_name = Google::StringUtils.uncombine(object.name) -%>
 <% if example.dependencies -%>


### PR DESCRIPTION
this pr includes tow commits:
1. support example
2. support index resource by name, which can enhance the ease of use. Because users prefer the name to the id of resource to manage the resource. **Note**: it can not update the name of resource but use the name to index resource, which will create a new resource with new name. If it want to do that, use the id to index resource instead.