### PR TITLE
use HwcSession like singleton

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -168,17 +168,16 @@ module Provider
                      "\n"
                    ], 4),
             indent([
-                     'combined = {}',
-                     'combined.update(module.params)',
+                     'combined = session.module.params.copy()',
                      'combined.update(extra_data)',
                      "\n"
                    ], 4),
             (indent([
-                      "combined['project'] = get_project_id(module)",
+                      "combined['project'] = session.get_project_id()",
                       "\n",
                     ], 4) if url.include?("{project}")),
             (indent([
-                      "endpoint = get_service_endpoint(module, \'#{service_type}\')",
+                      "endpoint = session.get_service_endpoint(\'#{service_type}\')",
                       "combined['endpoint'] = endpoint",
                       "\n",
                       "url = \"{endpoint}#{url}#{extra}\"".gsub('<|extra|>', ''),
@@ -189,7 +188,7 @@ module Provider
                    ], 4)
           ].compact.join("\n")
         else
-          url_code = "\"#{url}\".format(**module.params)#{extra}"
+          url_code = "\"#{url}\".format(**session.module.params)#{extra}"
           if url.include?("{project}")
             url_code = "\"#{url}\".format(**combined)#{extra}"
           end
@@ -198,14 +197,14 @@ module Provider
             "@link_wrapper",
             "def #{name}(#{params.join(', ')}):",
             (indent([
-                      'combined = module.params.copy()',
-                      "combined['project'] = get_project_id(module)",
+                      'combined = session.module.params.copy()',
+                      "combined['project'] = session.get_project_id()",
                       "\n",
                     ], 4) if url.include?("{project}")),
             (indent("return #{url_code}", 4).gsub('<|extra|>', '') if url.start_with?("http")),
             (indent([
                       "url = #{url_code}".gsub('<|extra|>', ''),
-                      "endpoint = get_service_endpoint(module, \'#{service_type}\')",
+                      "endpoint = session.get_service_endpoint(\'#{service_type}\')",
                       "return endpoint + url"
                     ], 4) if not url.start_with?("http")),
           ].compact.join("\n")
@@ -250,7 +249,7 @@ module Provider
       def emit_link_var_args(url, extra_data)
         extra_url = url.include?('<|extra|>')
         [
-          'module', ("extra_url=''" if extra_url),
+          'session', ("extra_url=''" if extra_url),
           ('extra_data=None' if extra_data)
         ].compact
       end

--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -7,14 +7,15 @@
   res_url = async_operation_url(object, object.async.result.base_url)
 -%>
 @link_wrapper
-def resource_get_url(module, wait_done):
-    combined = {'op_id': navigate_hash(wait_done, <%= res_path -%>)}
+def resource_get_url(session, wait_done):
+    combined = session.module.params.copy()
+    combined['op_id'] = navigate_hash(wait_done, <%= res_path -%>)
 <% if res_url.include? '{project}' -%>
-    combined['project'] = get_project_id(module)
+    combined['project'] = get_project_id(session)
 <% end-%>
     url = <%=quote_string(res_url)%>.format(**combined)
 
-    endpoint = get_service_endpoint(module, <%=quote_string(object.service_type)%>)
+    endpoint = session.get_service_endpoint(<%=quote_string(object.service_type)%>)
     return endpoint + url
 
 
@@ -31,34 +32,35 @@ def resource_get_url(module, wait_done):
   u_complete_states = object.async.update_status.complete.compact.map { |x| quote_string(x) }
   u_allowed_states = [u_allowed_states, u_complete_states].flatten
 -%>
-def wait_for_operation(module, op_type, op_result):
+def wait_for_operation(session, op_type, op_result):
     op_id = navigate_hash(op_result, <%= op_path -%>)
-    url = async_op_url(module, {'op_id': op_id})
-    timeout = 60 * int(module.params['timeouts'][op_type].rstrip('m'))
+    url = async_op_url(session, {'op_id': op_id})
+    timeout = 60 * int(session.module.params['timeouts'][op_type].rstrip('m'))
     states = {
         'create': {
-	    'allowed': [<%= c_allowed_states.join(', ') -%>],
-	    'complete': [<%= c_complete_states.join(', ') -%>],
-	},
+            'allowed': [<%= c_allowed_states.join(', ') -%>],
+            'complete': [<%= c_complete_states.join(', ') -%>],
+        },
         'update': {
-	    'allowed': [<%= u_allowed_states.join(', ') -%>] ,
-	    'complete': [<%= u_complete_states.join(', ') -%>],
-	}
+            'allowed': [<%= u_allowed_states.join(', ') -%>] ,
+            'complete': [<%= u_complete_states.join(', ') -%>],
+        }
     }
 
     return wait_for_completion(url, timeout, states[op_type]['allowed'],
-                               states[op_type]['complete'], module)
+                               states[op_type]['complete'], session)
 
 
 def wait_for_completion(op_uri, timeout, allowed_states,
-                        complete_states, module):
+                        complete_states, session):
+    module = session.module
     end = time.time() + timeout
     while time.time() <= end:
         try:
 <% if object.kind? -%>
-            op_result = fetch_resource(module, op_uri, '<%= op_kind -%>')
+            op_result = fetch_resource(session, op_uri, '<%= op_kind -%>')
 <% else # object.kind? -%>
-            op_result = fetch_resource(module, op_uri)
+            op_result = fetch_resource(session, op_uri)
 <% end # object.kind? -%>
         except Exception:
             time.sleep(<%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>)
@@ -76,13 +78,13 @@ def wait_for_completion(op_uri, timeout, allowed_states,
 
     module.fail_json(msg="Timeout to wait completion")
 <% else -%>
-def wait_for_operation(module, op_type, op_result):
+def wait_for_operation(session, op_type, op_result):
     op_id = navigate_hash(op_result, <%= op_path -%>)
-    url = async_op_url(module, {'op_id': op_id})
-    timeout = 60 * int(module.params['timeouts'][op_type].rstrip('m'))
+    url = async_op_url(session, {'op_id': op_id})
+    timeout = 60 * int(session.module.params['timeouts'][op_type].rstrip('m'))
 
 <% if object.self_link_query.nil? -%>
-    return wait_for_completion(url, timeout, module)
+    return wait_for_completion(url, timeout, session)
 <% else # object.self_link_query.nil? -%>
     wait_for_completion(status, op_result, resource)
 <%=
@@ -115,19 +117,20 @@ def wait_for_operation(module, op_type, op_result):
 <% end # object.self_link_query.nil? -%>
 
 
-def wait_for_completion(op_uri, timeout, module):
+def wait_for_completion(op_uri, timeout, session):
 <%
   allowed_states = object.async.status.allowed.compact.map { |x| quote_string(x) }
   complete_states = object.async.status.complete.compact.map { |x| quote_string(x) }
   allowed_states = [allowed_states, complete_states].flatten
 -%>
+    module = session.module
     end = time.time() + timeout
     while time.time() <= end:
         try:
 <% if object.kind? -%>
-            op_result = fetch_resource(module, op_uri, '<%= op_kind -%>')
+            op_result = fetch_resource(session, op_uri, '<%= op_kind -%>')
 <% else # object.kind? -%>
-            op_result = fetch_resource(module, op_uri)
+            op_result = fetch_resource(session, op_uri)
 <% end # object.kind? -%>
         except Exception:
             time.sleep(<%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>)
@@ -158,13 +161,12 @@ def raise_if_errors(response, module):
 <%   if (not async_op_st || async_op_st == object.service_type) && async_op_url == object_self_link -%>
 
 
-def wait_for_delete(module, link):
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
+def wait_for_delete(session, link):
     end = time.time() + 60 * int(
-        module.params['timeouts']['delete'].rstrip('m'))
+        session.module.params['timeouts']['delete'].rstrip('m'))
     while time.time() <= end:
         try:
-            resp = auth.get(link)
+            resp = session.get(link)
             if resp.status_code == 404:
                 return
         except Exception:
@@ -172,6 +174,6 @@ def wait_for_delete(module, link):
 
         time.sleep(<%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>)
 
-    module.fail_json(msg="Timeout to wait for deletion to be complete")
+    session.module.fail_json(msg="Timeout to wait for deletion to be complete")
 <%   end -%>
 <% end #if object.async -%>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -86,6 +86,7 @@ import json
 ###############################################################################
 
 
+<% prod_name = object.__product.prefix[1..-1] -%>
 def main():
     """Main function"""
 
@@ -93,17 +94,17 @@ def main():
   mod_props = object.all_user_properties.reject(&:output).map do |prop|
     python_dict_for_property(prop, object)
   end
-  obj_update_url = 'self_link(module)'
-  obj_delete_url = 'self_link(module)'
+  obj_update_url = 'self_link(session)'
+  obj_delete_url = 'self_link(session)'
   if object.update_url && object.delete_url && object.update_url == object.delete_url
-    obj_update_url = 'update_delete_url(module)'
-    obj_delete_url = 'update_delete_url(module)'
+    obj_update_url = 'update_delete_url(session)'
+    obj_delete_url = 'update_delete_url(session)'
   else
     if object.update_url
-      obj_update_url = 'update_url(module)'
+      obj_update_url = 'update_url(session)'
     end
     if object.delete_url
-      obj_delete_url = 'delete_url(module)'
+      obj_delete_url = 'delete_url(session)'
     end
   end
 -%>
@@ -113,6 +114,7 @@ def main():
 <%= lines(indent_list(mod_props, 12)) -%>
         )
     )
+    session = HwcSession(module, <%= quote_string(prod_name) -%>)
 
     state = module.params['state']
 <% if object.kind? -%>
@@ -124,18 +126,18 @@ def main():
 
 <% if object.self_link_query.nil? -%>
 <%
-  method = method_call('fetch_resource', ['module', 'link',
+  method = method_call('fetch_resource', ['session', 'link',
                                           ('kind' if object.kind?),
 					  ('[' + object.get_codes.join(', ') + ']' if object.get_codes)
                                          ])
 -%>
 <% if self_link_url(object).match('/{id}') -%>
     if (not module.params.get("id")) and module.params.get("name"):
-        module.params['id'] = get_id_by_name(module)
+        module.params['id'] = get_id_by_name(session)
 
 <% end -%>
     fetch = None
-    link = self_link(module)
+    link = self_link(session)
     # the link will include Nones if required format parameters are missed
     if not re.search('/None/|/None$', link):
         fetch = <%= method %>
@@ -159,7 +161,7 @@ def main():
             if is_different(module, fetch):
 <%
   method = method_call('update', [
-                                   'module', obj_update_url,
+                                   'session', obj_update_url,
                                    ('kind' if object.kind?),
                                    ('fetch' if object.save_api_results?),
                                    ('[' + object.update_codes.join(', ') + ']' if object.update_codes)
@@ -174,7 +176,7 @@ def main():
         else:
 <%
   method = method_call('delete', [
-                                   'module', obj_delete_url,
+                                   'session', obj_delete_url,
                                    ('kind' if object.kind?),
 				   ('fetch' if object.save_api_results?),
 				   ('[' + object.delete_codes.join(', ') + ']' if object.delete_codes)
@@ -187,13 +189,13 @@ def main():
         if state == 'present':
 <%
   if object.create_verb.nil? || object.create_verb == :POST
-    create_link = 'collection(module)'
+    create_link = 'collection(session)'
   elsif object.create_verb == :PUT
-    create_link = 'self_link(module)'
+    create_link = 'self_link(session)'
   else
     raise "Ansible does not support create_verb #{object.create_verb}"
   end
-  method = method_call('create', ['module', create_link,
+  method = method_call('create', ['session', create_link,
 				  ('kind' if object.kind?),
 				  ('[' + object.create_codes.join(', ') + ']' if object.create_codes)])
 -%>
@@ -209,14 +211,12 @@ def main():
     module.exit_json(**fetch)
 
 
-<% prod_name = object.__product.prefix[1..-1] -%>
 <% unless object.virtual -%>
 <%# TODO: kind param not always needed.
   # https://github.com/GoogleCloudPlatform/magic-modules/issues/45
 -%>
-<%= method_decl('create', ['module', 'link', ('kind' if object.kind?), 'success_codes=None']) %>
+<%= method_decl('create', ['session', 'link', ('kind' if object.kind?), 'success_codes=None']) %>
 <% if object.create.nil? -%>
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
     if not success_codes:
         success_codes = [201, 202]
 <%
@@ -228,11 +228,12 @@ def main():
     raise "Ansible does not support create_verb #{object.create_verb}"
   end
 -%>
+    module = session.module
 <%
   method = method_call(
     'return_if_object',
     ['module',
-     method_call("auth#{create_verb}",
+     method_call("session#{create_verb}",
                  ['link', 'resource_to_create(module)']),
      ('kind' if !object.async && object.kind?),
      'success_codes'
@@ -244,11 +245,11 @@ def main():
 <%   else -%>
     r = <%= method %>
 
-    wait_done = wait_for_operation(module, 'create', r)
+    wait_done = wait_for_operation(session, 'create', r)
 
-    url = resource_get_url(module, wait_done)
+    url = resource_get_url(session, wait_done)
 <%
-  method = method_call('fetch_resource', ['module', 'url',
+  method = method_call('fetch_resource', ['session', 'url',
                                           ('kind' if object.kind?),
 					  ('[' + object.get_codes.join(', ') + ']' if object.get_codes)
                                          ])
@@ -261,21 +262,21 @@ def main():
 
 
 <%=
-  lines(method_decl('update', ['module', 'link', ('kind' if object.kind?),
+  lines(method_decl('update', ['session', 'link', ('kind' if object.kind?),
 			       ('fetch' if object.save_api_results?),
 			       'success_codes=None']))
 -%>
 <% if object.update.nil? -%>
 <%   if !false?(object.editable) -%>
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
     if not success_codes:
         success_codes = [201, 202]
+    module = session.module
 <%
   method = method_call(
     'return_if_object',
     [
      'module',
-     method_call("auth.put", ['link', 'resource_to_update(module)']),
+     method_call("session.put", ['link', 'resource_to_update(module)']),
      ('kind' if !object.async && object.kind?),
      'success_codes'
    ]
@@ -286,11 +287,11 @@ def main():
 <%   else -%>
     r = <%= method %>
 
-    wait_done = wait_for_operation(module, 'update', r)
+    wait_done = wait_for_operation(session, 'update', r)
 
-    url = resource_get_url(module, wait_done)
+    url = resource_get_url(session, wait_done)
 <%
-  method = method_call('fetch_resource', ['module', 'url',
+  method = method_call('fetch_resource', ['session', 'url',
                                           ('kind' if object.kind?),
 					  ('[' + object.get_codes.join(', ') + ']' if object.get_codes)
                                          ])
@@ -306,19 +307,18 @@ def main():
 
 
 <%=
-  lines(method_decl('delete', ['module', 'link', ('kind' if object.kind?),
+  lines(method_decl('delete', ['session', 'link', ('kind' if object.kind?),
 			       ('fetch' if object.save_api_results?),
 			       'success_codes=None']))
 -%>
 <% if object.delete.nil? -%>
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
     if not success_codes:
         success_codes = [202, 204]
 <%
   method = method_call(
     'return_if_object',
-    ['module',
-     method_call("auth.delete", ['link']),
+    ['session.module',
+     method_call("session.delete", ['link']),
      ('kind' if !object.async && object.kind?),
      'success_codes',
      'False'
@@ -327,8 +327,8 @@ def main():
 
   method1 = method_call(
     'return_if_object',
-    ['module',
-     method_call("auth.delete", ['link']),
+    ['session.module',
+     method_call("session.delete", ['link']),
      ('kind' if !object.async && object.kind?),
      'success_codes'
    ]
@@ -345,11 +345,11 @@ def main():
 <%     if (not async_op_st || async_op_st == object.service_type) && async_op_url == object_self_link -%>
     <%= method %>
 
-    wait_for_delete(module, link)
+    wait_for_delete(session, link)
 <%     else -%>
     r = <%= method1 %>
 
-    wait_for_operation(module, 'delete', r)
+    wait_for_operation(session, 'delete', r)
 <%     end -%>
 <%   end -%>
 <% else # if object.delete.nil? -%>
@@ -371,14 +371,15 @@ def link_wrapper(f):
 
 
 <% unless object.virtual || self_link_url(object).match('/{id}').nil? -%>
-def get_id_by_name(module):
+def get_id_by_name(session):
+    module = session.module
     name = module.params.get("name")
-    link = list_link(module, {'limit': 10, 'marker': '{marker}'})
+    link = list_link(session, {'limit': 10, 'marker': '{marker}'})
     not_format_keys = re.findall("={marker}", link)
     none_values = re.findall("=None", link)
 
     if not (not_format_keys or none_values):
-        r = fetch_resource(module, link)
+        r = fetch_resource(session, link)
         if r is None:
             return ""
 <%   if object.list_msg_prefix -%>
@@ -394,12 +395,13 @@ def get_id_by_name(module):
         else:
             module.fail_json(msg="Multiple resources with same name are found")
     elif none_values:
-        module.fail_json(msg="Can not find id by name because url includes None")
+        module.fail_json(
+            msg="Can not find id by name because url includes None")
     else:
         p = {'marker': ''}
         ids = set()
         while True:
-            r = fetch_resource(module, link.format(**p))
+            r = fetch_resource(session, link.format(**p))
             if r is None:
                 break
 <%   if object.list_msg_prefix -%>
@@ -411,7 +413,8 @@ def get_id_by_name(module):
                 if i.get('name') == name:
                     ids.add(i.get('id'))
             if len(ids) >= 2:
-                module.fail_json(msg="Multiple resources with same name are found")
+                module.fail_json(
+                    msg="Multiple resources with same name are found")
 
             p['marker'] = r[-1].get('id')
 
@@ -461,18 +464,6 @@ def get_id_by_name(module):
     end
   end
 -%>
-def get_service_endpoint(module, service_type):
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
-    return auth.get_service_endpoint(service_type)
-
-
-<% if object.base_url.include? "{project}" -%>
-def get_project_id(module):
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
-    return auth.get_project_id()
-
-
-<% end -%>
 <%=
   lines(method_decl('return_if_object', ['module', 'response',
 					 ('kind' if object.kind?),

--- a/templates/ansible/transport.erb
+++ b/templates/ansible/transport.erb
@@ -16,17 +16,15 @@
 # limitations under the License.
 <% end -%>
 <% if object.kind? -%>
-def fetch_resource(module, link, kind, success_codes=None):
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
+def fetch_resource(session, link, kind, success_codes=None):
     if not success_codes:
         success_codes = [200]
-    return return_if_object(module, auth.get(link), kind, success_code)
+    return return_if_object(session.module, session.get(link), kind, success_code)
 <% else # object.kind? -%>
-def fetch_resource(module, link, success_codes=None):
-    auth = HwcSession(module, <%= quote_string(prod_name) -%>)
+def fetch_resource(session, link, success_codes=None):
     if not success_codes:
         success_codes = [200]
-    return return_if_object(module, auth.get(link), success_codes)
+    return return_if_object(session.module, session.get(link), success_codes)
 
 <% end # object.kind? -%>
 


### PR DESCRIPTION
before, it will create an instance of HwcSession each time getting enpoint, getting project id, calling the backend sercie etc, which will leads to create multiple tokens. actually, for a single module, it is fine to use only one instance of it. Because, there is only one user for a module, which means it can reuse the instance of HwcSession to call the back-end service, and it will create only one token between calls to service.